### PR TITLE
📌ISSUE-#172: Replace sentinel-based script input with text editor

### DIFF
--- a/linux_profile/base/system.py
+++ b/linux_profile/base/system.py
@@ -41,8 +41,9 @@ class System:
         if self.debug:
             self.debug_command = cmd
             print(cmd)
+            return 0
         else:
-            _system(cmd)
+            return _system(cmd)
 
     def setup_default(self):
         return "Method not Implemented"

--- a/linux_profile/commands/add.py
+++ b/linux_profile/commands/add.py
@@ -63,7 +63,10 @@ class Add(Settings):
             path = self.Base.path_temp.joinpath("temp_script")
             editor = input(f"Enter text editor [{self.text_editor}]: ") or self.text_editor
 
-            System().system(cmd=[editor, str(path)])
+            exit_code = System().system(cmd=[editor, str(path)])
+            if exit_code != 0:
+                raise RuntimeError(
+                    f"Editor '{editor}' exited with code {exit_code}. Script not saved.")
 
             if path.exists():
                 body = File.read(path_file=path).splitlines()

--- a/linux_profile/commands/add.py
+++ b/linux_profile/commands/add.py
@@ -74,7 +74,7 @@ class Add(Settings):
                 finally:
                     path.unlink(missing_ok=True)
                 return body
-            return []
+            raise ValueError("No script body provided — editor exited without saving.")
 
         fields = InputAddScript(**{
             "tag": option(text="Script Tag [default]: "),

--- a/linux_profile/commands/add.py
+++ b/linux_profile/commands/add.py
@@ -69,8 +69,10 @@ class Add(Settings):
                     f"Editor '{editor}' exited with code {exit_code}. Script not saved.")
 
             if path.exists():
-                body = File.read(path_file=path).splitlines()
-                path.unlink()
+                try:
+                    body = File.read(path_file=path).splitlines()
+                finally:
+                    path.unlink(missing_ok=True)
                 return body
             return []
 

--- a/linux_profile/commands/add.py
+++ b/linux_profile/commands/add.py
@@ -1,3 +1,7 @@
+import os
+import tempfile
+from pathlib import Path
+
 from linux_profile.base.file import File
 from linux_profile.base.system import System
 from linux_profile.base.action import Action
@@ -60,7 +64,10 @@ class Add(Settings):
     def add_script(self):
 
         def option_body():
-            path = self.Base.path_temp.joinpath("temp_script")
+            fd, tmp = tempfile.mkstemp(
+                prefix="linuxp_script_", dir=self.Base.path_temp)
+            os.close(fd)
+            path = Path(tmp)
             editor = input(f"Enter text editor [{self.text_editor}]: ") or self.text_editor
 
             exit_code = System().system(cmd=[editor, str(path)])

--- a/linux_profile/commands/add.py
+++ b/linux_profile/commands/add.py
@@ -58,11 +58,24 @@ class Add(Settings):
         )
 
     def add_script(self):
+
+        def option_body():
+            path = self.Base.path_temp.joinpath("temp_script")
+            editor = input(f"Enter text editor [{self.text_editor}]: ") or self.text_editor
+
+            System().system(cmd=[editor, str(path)])
+
+            if path.exists():
+                body = File.read(path_file=path).splitlines()
+                path.unlink()
+                return body
+            return []
+
         fields = InputAddScript(**{
             "tag": option(text="Script Tag [default]: "),
             "type": option(text="Script Type: ", required=True),
             "name": option(text="Script Name: ", required=True),
-            "body": option(text="Script Body: ", required=True, body=True),
+            "body": option_body(),
             "shebang": option(text="Script Shebang: "),
             "description": option(text="Package Description [limit 85]: ")}
         )

--- a/tests/core/base/test_base_system.py
+++ b/tests/core/base/test_base_system.py
@@ -23,3 +23,21 @@ def test_base_system_standard_variables_check():
     assert item.sudo == False
     assert item.command == 'exec'
     assert item.type == 'default'
+
+
+def test_base_system_method_returns_zero_in_debug_mode():
+    item = SystemTest(debug=True)
+    result = item.system(cmd=["echo", "hello"])
+    assert result == 0
+
+
+def test_base_system_method_returns_zero_on_success():
+    item = SystemTest()
+    result = item.system(cmd=["true"])
+    assert result == 0
+
+
+def test_base_system_method_returns_nonzero_on_failure():
+    item = SystemTest()
+    result = item.system(cmd=["false"])
+    assert result != 0

--- a/tests/core/commands/test_add_script.py
+++ b/tests/core/commands/test_add_script.py
@@ -1,0 +1,144 @@
+"""Tests for the option_body() closure introduced in add_script (PR #181 / Issue #172)."""
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from linux_profile.base.file import File
+from linux_profile.base.system import System
+
+
+# ---------------------------------------------------------------------------
+# Standalone replica of option_body() for isolated unit testing.
+# Mirrors the production closure in linux_profile/commands/add.py exactly,
+# accepting path_temp and text_editor as parameters instead of via self.
+# ---------------------------------------------------------------------------
+
+def _option_body(path_temp, text_editor="vim"):
+    fd, tmp = tempfile.mkstemp(prefix="linuxp_script_", dir=path_temp)
+    os.close(fd)
+    path = Path(tmp)
+    editor = text_editor
+
+    exit_code = System().system(cmd=[editor, str(path)])
+    if exit_code != 0:
+        raise RuntimeError(
+            f"Editor '{editor}' exited with code {exit_code}. Script not saved.")
+
+    if path.exists():
+        try:
+            body = File.read(path_file=path).splitlines()
+        finally:
+            path.unlink(missing_ok=True)
+        return body
+    raise ValueError("No script body provided — editor exited without saving.")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_option_body_returns_list_of_lines(tmp_path):
+    """Editor writes content — option_body() returns a list of lines."""
+    def fake_editor(cmd):
+        Path(cmd[-1]).write_text("line1\nline2\nline3\n")
+        return 0
+
+    with patch.object(System, "system", side_effect=fake_editor):
+        result = _option_body(path_temp=tmp_path)
+
+    assert result == ["line1", "line2", "line3"]
+
+
+def test_option_body_temp_file_deleted_after_read(tmp_path):
+    """Temp file is deleted after content is read successfully."""
+    captured_path = {}
+
+    def fake_editor(cmd):
+        p = Path(cmd[-1])
+        captured_path["path"] = p
+        p.write_text("echo hello\n")
+        return 0
+
+    with patch.object(System, "system", side_effect=fake_editor):
+        _option_body(path_temp=tmp_path)
+
+    assert not captured_path["path"].exists()
+
+
+def test_option_body_temp_file_deleted_on_read_exception(tmp_path):
+    """Temp file is deleted even when File.read() raises an exception."""
+    captured_path = {}
+
+    def fake_editor(cmd):
+        p = Path(cmd[-1])
+        captured_path["path"] = p
+        p.write_text("content")
+        return 0
+
+    with patch.object(System, "system", side_effect=fake_editor):
+        with patch("linux_profile.base.file.File.read", side_effect=Exception("read error")):
+            try:
+                _option_body(path_temp=tmp_path)
+            except Exception:
+                pass
+
+    assert not captured_path["path"].exists()
+
+
+def test_option_body_raises_runtime_error_on_nonzero_exit(tmp_path):
+    """RuntimeError is raised when the editor exits with a non-zero code."""
+    with patch.object(System, "system", return_value=127):
+        try:
+            _option_body(path_temp=tmp_path, text_editor="nonexistent_editor")
+            assert False, "Expected RuntimeError"
+        except RuntimeError as error:
+            assert "nonexistent_editor" in str(error)
+            assert "127" in str(error)
+
+
+def test_option_body_raises_value_error_when_file_not_saved(tmp_path):
+    """ValueError is raised when the editor exits with code 0 but saves nothing."""
+    def fake_editor(cmd):
+        Path(cmd[-1]).unlink(missing_ok=True)
+        return 0
+
+    with patch.object(System, "system", side_effect=fake_editor):
+        try:
+            _option_body(path_temp=tmp_path)
+            assert False, "Expected ValueError"
+        except ValueError as error:
+            assert "No script body provided" in str(error)
+
+
+def test_option_body_unique_temp_files_per_invocation(tmp_path):
+    """Each call to option_body() creates a distinct temp file path."""
+    paths = []
+
+    def fake_editor(cmd):
+        p = Path(cmd[-1])
+        paths.append(p)
+        p.write_text("body\n")
+        return 0
+
+    with patch.object(System, "system", side_effect=fake_editor):
+        _option_body(path_temp=tmp_path)
+        _option_body(path_temp=tmp_path)
+
+    assert paths[0] != paths[1]
+
+
+def test_option_body_temp_file_has_correct_prefix(tmp_path):
+    """Temp file name starts with the expected prefix."""
+    captured_path = {}
+
+    def fake_editor(cmd):
+        p = Path(cmd[-1])
+        captured_path["path"] = p
+        p.write_text("body\n")
+        return 0
+
+    with patch.object(System, "system", side_effect=fake_editor):
+        _option_body(path_temp=tmp_path)
+
+    assert captured_path["path"].name.startswith("linuxp_script_")


### PR DESCRIPTION
## Description

- `linux_profile/commands/add.py`: replaced the sentinel-based input loop in `add_script` with a text editor flow, following the same pattern already used by `add_file`.

## Motivation and Context

The `add_script` command used the string `end` as a sentinel to terminate multiline input. This conflicts with Ruby's `end` keyword (required to close blocks, methods, and classes), causing any Ruby script to be silently truncated the moment the first `end` is typed. The same conflict exists for Lua and other languages that use `end` as a keyword.

Closes #172

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly