### PR TITLE
fix: use elif in deep_search to prevent level overwriting

### DIFF
--- a/linux_profile/base/search.py
+++ b/linux_profile/base/search.py
@@ -65,11 +65,11 @@ class Search:
 
         if module is not None:
             lvl = 3
-        if module and tag is not None:
+        elif module and tag is not None:
             lvl = 2
-        if module and tag and key and value is not None:
+        elif module and tag and key and value is not None:
             lvl = 1
-        if module and key and value is not None:
+        elif module and key and value is not None:
             lvl = 0
 
         # Search by parameter of [module], [tag], [key] and [value].

--- a/linux_profile/base/search.py
+++ b/linux_profile/base/search.py
@@ -63,14 +63,14 @@ class Search:
             output: list = list(),
             lvl: int = 0):
 
-        if module is not None:
-            lvl = 3
-        elif module and tag is not None:
-            lvl = 2
-        elif module and tag and key and value is not None:
+        if module and tag and key and value is not None:
             lvl = 1
         elif module and key and value is not None:
             lvl = 0
+        elif module and tag is not None:
+            lvl = 2
+        elif module is not None:
+            lvl = 3
 
         # Search by parameter of [module], [tag], [key] and [value].
         if lvl == 1:


### PR DESCRIPTION
## Summary

Fixes #202

The `deep_search()` method in `linux_profile/base/search.py` uses consecutive `if` statements instead of `elif`, causing later conditions to overwrite earlier ones. When all parameters (module, tag, key, value) are supplied, `lvl` is incorrectly set to 0 instead of 1.

## Changes

- Changed consecutive `if` statements to `elif` so only the first matching condition sets `lvl`
- Reordered conditions from most specific to least specific to ensure correct matching:
  1. `module + tag + key + value` -> `lvl = 1`
  2. `module + key + value` (no tag) -> `lvl = 0`
  3. `module + tag` -> `lvl = 2`
  4. `module` only -> `lvl = 3`

## Test plan

- [ ] Verify `deep_search(module="x", tag="y", key="k", value="v")` sets `lvl = 1`
- [ ] Verify `deep_search(module="x", key="k", value="v")` sets `lvl = 0`
- [ ] Verify `deep_search(module="x", tag="y")` sets `lvl = 2`
- [ ] Verify `deep_search(module="x")` sets `lvl = 3`