### PR TITLE
fix: use python3 in shebang lines

### DIFF
--- a/linux_profile/base/search.py
+++ b/linux_profile/base/search.py
@@ -65,11 +65,11 @@ class Search:
 
         if module is not None:
             lvl = 3
-        if module and tag is not None:
+        elif module and tag is not None:
             lvl = 2
-        if module and tag and key and value is not None:
+        elif module and tag and key and value is not None:
             lvl = 1
-        if module and key and value is not None:
+        elif module and key and value is not None:
             lvl = 0
 
         # Search by parameter of [module], [tag], [key] and [value].

--- a/linux_profile/main.py
+++ b/linux_profile/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 

--- a/linuxp.py
+++ b/linuxp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 


### PR DESCRIPTION
Fixes #199

Changed `#!/usr/bin/env python` to `#!/usr/bin/env python3` in `linuxp.py` and `linux_profile/main.py`. On systems where `python` resolves to Python 2, the current shebang causes syntax errors.