### PR TITLE
fix: add feedback for unimplemented execute command

### DIFF
--- a/linux_profile/base/search.py
+++ b/linux_profile/base/search.py
@@ -65,11 +65,11 @@ class Search:
 
         if module is not None:
             lvl = 3
-        if module and tag is not None:
+        elif module and tag is not None:
             lvl = 2
-        if module and tag and key and value is not None:
+        elif module and tag and key and value is not None:
             lvl = 1
-        if module and key and value is not None:
+        elif module and key and value is not None:
             lvl = 0
 
         # Search by parameter of [module], [tag], [key] and [value].

--- a/linux_profile/commands/execute.py
+++ b/linux_profile/commands/execute.py
@@ -5,3 +5,5 @@ class Execute(Settings):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        print("Error: 'execute' command is not yet implemented.")
+        print("See https://github.com/linux-profile/linux-profile for updates.")


### PR DESCRIPTION
Fixes #201

The `Execute` command class had no implementation, so `linuxp execute` silently succeeded with no output. Added a clear error message.