### PR TITLE
fix: preserve falsy values in Validator.__init__

### DIFF
--- a/linux_profile/base/validator.py
+++ b/linux_profile/base/validator.py
@@ -12,7 +12,7 @@ class Validator():
         self.id = self.get_uuid()
 
         for arg in kwargs:
-            value = kwargs.get(arg) if kwargs.get(arg) else None
+            value = kwargs.get(arg) if kwargs.get(arg) is not None else None
             setattr(self, arg, value)
 
             if hasattr(self, "validator_" + arg):


### PR DESCRIPTION
## Summary
- Fix `Validator.__init__` truthiness check that incorrectly replaces valid falsy values (`0`, `False`, `""`) with `None`
- Changed `kwargs.get(arg) if kwargs.get(arg) else None` to `kwargs.get(arg) if kwargs.get(arg) is not None else None`
- This preserves intentional falsy values while still defaulting missing keys to `None`

## Test plan
- [ ] Verify `Validator(count=0)` preserves `0` instead of replacing with `None`
- [ ] Verify `Validator(flag=False)` preserves `False` instead of replacing with `None`
- [ ] Verify `Validator(name="")` preserves `""` instead of replacing with `None`
- [ ] Verify `Validator(value=None)` still correctly sets `None`
- [ ] Verify existing tests pass with `pytest`

Fixes #197